### PR TITLE
Expose reaction sorting to CLI & OpenCL `pown` calls with internal power function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,13 @@ language: python
 matrix:
   include:
     - python: "3.6"
-      env: ISFLAKE="0" TEST_LANGS="opencl"
+      env: ISFLAKE="0" PYJAC_TEST_LANGS="opencl"
     - python: "3.6"
-      env: ISFLAKE="0" TEST_LANGS="c"
+      env: ISFLAKE="0" PYJAC_TEST_LANGS="c"
+    - python: "3.6"
+      env: ISFLAKE="0" PYJAC_TEST_LANGS="opencl" PYJAC_RXN_SORTING="simd"
+    - python: "3.6"
+      env: ISFLAKE="0" PYJAC_TEST_LANGS="c" PYJAC_RXN_SORTING="simd"
     - python: "3.6"
       env: ISFLAKE="1"
 

--- a/pyjac/core/create_jacobian.py
+++ b/pyjac/core/create_jacobian.py
@@ -1325,7 +1325,8 @@ def __dRopidE(loopy_opts, namestore, test_size=None,
         # TODO: forward allint to this function
         # get the appropriate power function and calls
         power_func = utils.power_function(loopy_opts.lang, is_integer_power=True,
-                                          guard_nonzero=True)
+                                          guard_nonzero=True,
+                                          is_vector=loopy_opts.is_simd)
         nu_fwd = 'nu_fwd'
         nu_rev = 'nu_rev'
         pow_conc_fwd = power_func(conc_str, nu_fwd)
@@ -2980,7 +2981,8 @@ def __dRopidT(loopy_opts, namestore, test_size=None,
         # TODO: forward allint to this function
         # create appropriate power functions
         power_func = utils.power_function(loopy_opts.lang, is_integer_power=True,
-                                          guard_nonzero=True)
+                                          guard_nonzero=True,
+                                          is_vector=loopy_opts.is_simd)
         nu_fwd = 'nu_fwd'
         nu_rev = 'nu_rev'
         pow_conc_fwd = power_func(conc_str, nu_fwd)
@@ -4310,7 +4312,8 @@ def __dropidnj(loopy_opts, namestore, allint, test_size=None,
 
     # get the appropriate power function and calls
     power_func = utils.power_function(loopy_opts.lang, is_integer_power=allint,
-                                      guard_nonzero=True)
+                                      guard_nonzero=True,
+                                      is_vector=loopy_opts.is_simd)
     nu_fwd = 'nu_fwd'
     nu_rev = 'nu_rev'
     pow_conc_fwd = power_func(conc_inner_str, nu_fwd)

--- a/pyjac/core/create_jacobian.py
+++ b/pyjac/core/create_jacobian.py
@@ -5332,11 +5332,6 @@ def create_jacobian(lang, mech_name=None, therm_name=None, gas=None,
                      'time')
         raise InvalidInputSpecificationException(['wide', 'deep'])
 
-    if jac_type == JacobianType.finite_difference:
-        # convert mode
-        fd_mode = utils.EnumType(FiniteDifferenceMode)(
-            fd_mode.lower())
-
     # load platform if supplied
     device = None
     device_type = None

--- a/pyjac/core/create_jacobian.py
+++ b/pyjac/core/create_jacobian.py
@@ -33,7 +33,7 @@ from pyjac.loopy_utils import load_platform
 from pyjac.kernel_utils import kernel_gen as k_gen
 from pyjac.core import array_creator as arc
 from pyjac.core.enum_types import reaction_type, falloff_form, thd_body_type, \
-    KernelType
+    KernelType, reaction_sorting
 from pyjac.core import chem_model as chem
 from pyjac.core import instruction_creator as ic
 from pyjac.core.array_creator import (global_ind, var_name, default_inds)
@@ -5188,7 +5188,8 @@ def create_jacobian(lang, mech_name=None, therm_name=None, gas=None,
                     jac_type=JacobianType.exact,
                     jac_format=JacobianFormat.full, for_validation=False,
                     fd_order=1, fd_mode=FiniteDifferenceMode.forward, mem_limits='',
-                    work_size=None, explicit_simd=False, **kwargs
+                    work_size=None, explicit_simd=False,
+                    rsort=reaction_sorting.none, **kwargs
                     ):
     """Create Jacobian subroutine from mechanism.
 
@@ -5399,9 +5400,9 @@ def create_jacobian(lang, mech_name=None, therm_name=None, gas=None,
     # Interpret reaction mechanism file, depending on Cantera or
     # Chemkin format.
     if gas is not None or mech_name.endswith(tuple(['.cti', '.xml'])):
-        elems, specs, reacs = mech.read_mech_ct(mech_name, gas)
+        elems, specs, reacs = mech.read_mech_ct(mech_name, gas, rsort)
     else:
-        elems, specs, reacs = mech.read_mech(mech_name, therm_name)
+        elems, specs, reacs = mech.read_mech(mech_name, therm_name, rsort)
 
     if not specs:
         logger.error('No species found in file: {}'.format(mech_name))

--- a/pyjac/core/mech_interpret.py
+++ b/pyjac/core/mech_interpret.py
@@ -96,8 +96,8 @@ def sort_reactions(reacs, sort_type, return_order=False):
             ordering = ordering[inds]
             sort_matrix = sort_matrix[inds]
 
-        if return_order:
-            return ordering
+    if return_order:
+        return ordering
 
     # sort reactions
     return [reacs[i] for i in ordering]

--- a/pyjac/core/mech_interpret.py
+++ b/pyjac/core/mech_interpret.py
@@ -68,33 +68,36 @@ def sort_reactions(reacs, sort_type, return_order=False):
 
     """
 
-    from pyjac.core.enum_types import (
-        reaction_type, falloff_form, reversible_type, thd_body_type)
-
-    # we consider the following enums:
-    # column #1, reaction type
-    # column #2, falloff form
-    # column #3, third body form
-    # column #4, reversible type
-
-    enum_order = (reaction_type, falloff_form, thd_body_type, reversible_type)
-    sort_matrix = np.empty((len(reacs), 4))
-    for i, rxn in enumerate(reacs):
-        for j, enum in enumerate(enum_order):
-            e_val = rxn.get_type(enum)
-            assert len(e_val) == 1
-            sort_matrix[i, j] = int(e_val[0])
-
     ordering = np.arange(len(reacs))
+    from pyjac.core.enum_types import reaction_sorting
+    if sort_type is not None and sort_type != reaction_sorting.none:
+        from pyjac.core.enum_types import (
+            reaction_type, falloff_form, reversible_type, thd_body_type)
 
-    # now sort by column -- https://stackoverflow.com/a/38194077
-    for i in reversed(range(len(enum_order))):
-        inds = sort_matrix[:, i].argsort(kind='mergesort')
-        ordering = ordering[inds]
-        sort_matrix = sort_matrix[inds]
+        # we consider the following enums:
+        # column #1, reaction type
+        # column #2, falloff form
+        # column #3, third body form
+        # column #4, reversible type
 
-    if return_order:
-        return ordering
+        enum_order = (reaction_type, falloff_form, thd_body_type, reversible_type)
+        sort_matrix = np.empty((len(reacs), 4))
+        for i, rxn in enumerate(reacs):
+            for j, enum in enumerate(enum_order):
+                e_val = rxn.get_type(enum)
+                assert len(e_val) == 1
+                sort_matrix[i, j] = int(e_val[0])
+
+        ordering = np.arange(len(reacs))
+
+        # now sort by column -- https://stackoverflow.com/a/38194077
+        for i in reversed(range(len(enum_order))):
+            inds = sort_matrix[:, i].argsort(kind='mergesort')
+            ordering = ordering[inds]
+            sort_matrix = sort_matrix[inds]
+
+        if return_order:
+            return ordering
 
     # sort reactions
     return [reacs[i] for i in ordering]

--- a/pyjac/core/rate_subs.py
+++ b/pyjac/core/rate_subs.py
@@ -1451,7 +1451,8 @@ def get_rop(loopy_opts, namestore, allint={'net': False}, test_size=None):
                          spec_ind=spec_ind)
 
         power_func = utils.power_function(loopy_opts.lang,
-                                          is_integer_power=allint['net'])
+                                          is_integer_power=allint['net'],
+                                          is_vector=loopy_opts.is_simd)
         # if all integers, it's much faster to use multiplication
         roptemp_eval = Template(
             """
@@ -1697,7 +1698,9 @@ def get_rev_rates(loopy_opts, namestore, allint, test_size=None):
 
     # get the right power function
     power_func = utils.power_function(loopy_opts.lang,
-                                      is_integer_power=allint['net'])
+                                      is_integer_power=allint['net'],
+                                      # both values here are scalar
+                                      is_vector=False)
 
     # create the pressure product loop
     pressure_prod = Template("""
@@ -2386,7 +2389,8 @@ def get_troe_kernel(loopy_opts, namestore, test_size=None):
 
     # get generic power function
     power_func = utils.power_function(loopy_opts.lang, is_integer_power=False,
-                                      is_positive_power=True)
+                                      is_positive_power=True,
+                                      is_vector=loopy_opts.is_simd)
 
     # make the instructions
     troe_instructions = Template("""
@@ -2491,10 +2495,12 @@ def get_sri_kernel(loopy_opts, namestore, test_size=None):
 
     # get generic power function
     pos_power_func = utils.power_function(loopy_opts.lang, is_integer_power=False,
-                                          is_positive_power=True)
+                                          is_positive_power=True,
+                                          is_vector=loopy_opts.is_simd)
     gen_power_func = utils.power_function(loopy_opts.lang,
-                                          is_positive_power=isinstance(
-                                            sri_e_lp.dtype, np.integer))
+                                          is_integer_power=isinstance(
+                                            sri_e_lp.dtype, np.integer),
+                                          is_vector=loopy_opts.is_simd)
 
     # create instruction set
     sri_instructions = Template("""
@@ -2779,7 +2785,8 @@ def get_simple_arrhenius_rates(loopy_opts, namestore, test_size=None,
         elif rtype == 1:
             if beta_iter > 1:
                 power_func = utils.power_function(
-                    loopy_opts.lang, is_integer_power=True, is_positive_power=True)
+                    loopy_opts.lang, is_integer_power=True, is_positive_power=True,
+                    is_vector=loopy_opts.is_simd)
                 beta_iter_str = Template("""
                 <int32> b_end = abs(${b_str})
                 kf_temp = kf_temp * ${power_func}(T_iter, b_end) \

--- a/pyjac/kernel_utils/kernel_gen.py
+++ b/pyjac/kernel_utils/kernel_gen.py
@@ -2728,9 +2728,10 @@ class kernel_generator(object):
             elif arry.name in [rhs_work_name, local_work_name, int_work_name]:
                 def _size(a):
                     from pymbolic import substitute
-                    from pymbolic.primitives import Product
+                    from pymbolic.primitives import Product, Sum
                     assert len(a.shape) == 1
-                    if isinstance(a.shape[0], Product):
+                    if isinstance(a.shape[0], Product) or isinstance(
+                            a.shape[0], Sum):
                         return substitute(a.shape[0], **{w_size.name: 1})
                     return a.shape[0]
 

--- a/pyjac/libgen/libgen.py
+++ b/pyjac/libgen/libgen.py
@@ -72,7 +72,9 @@ def get_toolchain(lang, shared=True, executable=True):
 
     # compilation flags
     compile_flags = opt_flags
-    if 'PYJAC_DEBUG' in os.environ and os.environ['PYJAC_DEBUG']:
+    from pyjac.tests import _get_test_input
+    # read debug flag from ENV or config
+    if _get_test_input('debug'):
         compile_flags = debug_flags
 
     # link flags

--- a/pyjac/loopy_utils/preambles_and_manglers.py
+++ b/pyjac/loopy_utils/preambles_and_manglers.py
@@ -172,7 +172,7 @@ class fastpowi_PreambleGen(PreambleGen):
         return 'cust_funcs_{}'.format(self.name)
 
 
-class fastpowiv_PreambleGen(PreambleGen):
+class fastpowiv_PreambleGen(fastpowi_PreambleGen):
     def __init__(self, integer_dtype=np.int32, vector_width=None):
         assert vector_width is not None
         super(fastpowiv_PreambleGen, self).__init__(
@@ -238,7 +238,10 @@ def power_function_manglers(loopy_opts, power_functions):
 
     def __manglers(power_function):
         pow_name = power_function.name
-        if loopy_opts.lang == 'opencl' and 'pow' in pow_name:
+        if pow_name in ['fast_powi', 'fast_powiv']:
+            # skip, handled as preamble
+            return []
+        elif loopy_opts.lang == 'opencl' and 'pow' in pow_name:
             # opencl only
             # create manglers
             manglers = []
@@ -273,9 +276,6 @@ def power_function_manglers(loopy_opts, power_functions):
                 manglers.append(mangler_type(arg_dtypes=(vfloat, vlong),
                                              result_dtypes=np.float64))
             return manglers
-        elif pow_name in ['fast_powi', 'fast_powiv']:
-            # skip, handled as preamble
-            return []
         else:
             return [powf()]
 

--- a/pyjac/loopy_utils/preambles_and_manglers.py
+++ b/pyjac/loopy_utils/preambles_and_manglers.py
@@ -121,11 +121,15 @@ class PreambleGen(object):
 
 
 class fastpowi_PreambleGen(PreambleGen):
-    def __init__(self, integer_dtype=np.int32):
+    def __init__(self, integer_dtype=np.int32, vector=None,
+                 name='fast_powi'):
         int_str = 'int' if integer_dtype == np.int32 else 'long'
+        double_str = 'double'
+        if vector:
+            double_str += str(vector)
         # operators
-        self.code = Template("""
-   inline double fast_powi(double val, ${int_str} pow)
+        code = Template("""
+   inline ${double_str} ${name}(${double_str} val, ${int_str} pow)
    {
         // account for negatives
         if (pow < 0)
@@ -149,22 +153,30 @@ class fastpowi_PreambleGen(PreambleGen):
             case 5:
                 return val * val * val * val * val;
         }
-        double retval = 1;
-        for (${int_str} i = 0; i < pow; ++i)
+        ${double_str} retval = val * val * val * val * val * val;
+        for (${int_str} i = 6; i < pow; ++i)
         {
             retval *= val;
         }
         return retval;
    }
-            """).substitute(int_str=int_str)
+            """).substitute(int_str=int_str, double_str=double_str,
+                            name=name)
 
         super(fastpowi_PreambleGen, self).__init__(
-            'fast_powi', self.code,
+            name, code,
             (np.float64, integer_dtype),
             (np.float64))
 
     def get_descriptor(self, func_match):
-        return 'cust_funcs_fastpowi'
+        return 'cust_funcs_{}'.format(self.name)
+
+
+class fastpowiv_PreambleGen(PreambleGen):
+    def __init__(self, integer_dtype=np.int32, vector_width=None):
+        assert vector_width is not None
+        super(fastpowiv_PreambleGen, self).__init__(
+            integer_dtype, vector=vector_width, name='fast_powiv')
 
 
 def power_function_preambles(loopy_opts, power_function):
@@ -183,6 +195,8 @@ def power_function_preambles(loopy_opts, power_function):
 
     if 'fast_powi' in [x.name for x in utils.listify(power_function)]:
         return [fastpowi_PreambleGen(arc.kint_type)]
+    if 'fast_powiv' in [x.name for x in utils.listify(power_function)]:
+        return [fastpowiv_PreambleGen(arc.kint_type, loopy_opts.vector_width)]
     return []
 
 
@@ -259,7 +273,7 @@ def power_function_manglers(loopy_opts, power_functions):
                 manglers.append(mangler_type(arg_dtypes=(vfloat, vlong),
                                              result_dtypes=np.float64))
             return manglers
-        elif pow_name == 'fast_powi':
+        elif pow_name in ['fast_powi', 'fast_powiv']:
             # skip, handled as preamble
             return []
         else:

--- a/pyjac/tests/__init__.py
+++ b/pyjac/tests/__init__.py
@@ -10,8 +10,10 @@ import loopy as lp
 from nose.tools import nottest
 
 # local imports
-from pyjac.core.mech_interpret import read_mech_ct
+from pyjac.core.mech_interpret import read_mech_ct, sort_reactions
 from pyjac.core import array_creator as arc
+from pyjac.core.enum_types import reaction_sorting
+from pyjac.utils import EnumType
 from pyjac import utils
 from pyjac.schemas import build_and_validate
 
@@ -32,7 +34,8 @@ def _get_test_input(key, default=''):
         logger.debug('Loading value {} = {} from testconfig'.format(
             key, config[key.lower()]))
         value = config[key.lower()]
-    if key.upper() in os.environ:
+    if 'PYJAC_' + key.upper() in os.environ:
+        key = 'PYJAC_' + key.upper()
         logger = logging.getLogger(__name__)
         logger.debug('{}Loading value {} = {} from environment'.format(
             'OVERRIDE: ' if in_config else '', key, os.environ[key.upper()]))
@@ -76,6 +79,13 @@ def get_mechanism_file():
     This can be set in :file:`test_setup.py` or via the command line
     """
     return _get_test_input('gas', os.path.join(script_dir, 'test.cti'))
+
+
+def get_rxn_sorting():
+    """
+    Returns the user specied or default reaction sorting method
+    """
+    return EnumType(reaction_sorting)(_get_test_input('rxn_sort', 'none'))
 
 
 @nottest
@@ -362,6 +372,19 @@ class TestClass(unittest.TestCase):
             gas = ct.Solution(gasname)
             # the mechanism
             elems, specs, reacs = read_mech_ct(gasname)
+            # get sort type
+            sorting = get_rxn_sorting()
+            if sorting != reaction_sorting.none:
+                # get ordering
+                ordering = sort_reactions(reacs, sorting, return_order=True)
+                # and apply
+                reacs = sort_reactions(reacs, sorting)
+                ct_reacs = gas.reactions()
+                # and apply to gas
+                gas = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
+                                  species=gas.species(), reactions=[
+                                    ct_reacs[i] for i in ordering])
+
             # and reassign
             utils.reassign_species_lists(reacs, specs)
             # and finally check for a test platform

--- a/pyjac/tests/test_utils/__init__.py
+++ b/pyjac/tests/test_utils/__init__.py
@@ -42,7 +42,7 @@ try:
     np_divmod = np.divmod
 except AttributeError:
     def np_divmod(a, b, **kwargs):
-        div, mod = divmod(a, b)
+        div, mod = divmod(np.array(a), np.array(b))
         return np.asarray(div, **kwargs), np.asarray(mod, **kwargs)
 
 import six

--- a/pyjac/utils.py
+++ b/pyjac/utils.py
@@ -1049,7 +1049,7 @@ def get_parser():
     from pyjac.core.enum_types import reaction_sorting
     parser.add_argument('--reaction_sorting',
                         type=EnumType(reaction_sorting),
-                        default=reaction_sorting.non,
+                        default=reaction_sorting.none,
                         help='Enable sorting of reactions [beta].')
     args = parser.parse_args()
     return args

--- a/pyjac/utils.py
+++ b/pyjac/utils.py
@@ -1046,6 +1046,11 @@ def get_parser():
                         dest='loglevel',
                         help='Increase verbosity of logging / output messages.',
                         default=logging.INFO)
+    from pyjac.core.enum_types import reaction_sorting
+    parser.add_argument('--reaction_sorting',
+                        type=EnumType(reaction_sorting),
+                        default=reaction_sorting.non,
+                        help='Enable sorting of reactions [beta].')
     args = parser.parse_args()
     return args
 

--- a/pyjac/utils.py
+++ b/pyjac/utils.py
@@ -271,22 +271,23 @@ class PowerFunction(object):
 
 
 def power_function(lang, is_integer_power=False, is_positive_power=False,
-                   guard_nonzero=False):
+                   guard_nonzero=False, is_vector=False):
     """
     Returns the best power function to use for a given :param:`lang` and
-    choice of :param:`is_integer_power` / :param:`is_positive_power`
+    choice of :param:`is_integer_power` / :param:`is_positive_power` and
+    the :param:`is_vector` status of the instruction in question
     """
 
-    if lang == 'opencl' and is_integer_power:
-        # opencl has it's own integer power function
-        # this also is nice for loopy, as it handles the vectorizability check
-        return PowerFunction('pown', lang, guard_nonzero=guard_nonzero)
-    elif lang == 'opencl' and is_positive_power:
+    if lang == 'opencl' and is_positive_power:
         # opencl positive power function -- no need for guard
         return PowerFunction('powr', lang)
     elif is_integer_power:
-        # use internal integer power function
-        return PowerFunction('fast_powi', lang, guard_nonzero=guard_nonzero)
+        # 10/01/18 -- don't use OpenCL's pown -> VERY SLOW on intel
+        # instead use internal integer power function
+        if is_vector:
+            return PowerFunction('fast_powiv', lang, guard_nonzero=guard_nonzero)
+        else:
+            return PowerFunction('fast_powi', lang, guard_nonzero=guard_nonzero)
     else:
         # use default
         return PowerFunction('pow', lang, guard_nonzero=guard_nonzero)

--- a/pyjac/utils.py
+++ b/pyjac/utils.py
@@ -1081,5 +1081,6 @@ def create(**kwargs):
                     jac_format=args.jac_format,
                     mem_limits=args.memory_limits,
                     work_size=args.work_size,
-                    explicit_simd=args.explicit_simd
+                    explicit_simd=args.explicit_simd,
+                    rsort=args.reaction_sorting
                     )

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ setup(
     # Choose your license
     license='MIT License',
 
+    # version
+    version=__version__,
+
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/test_setup.py
+++ b/test_setup.py
@@ -4,9 +4,10 @@
 # c) the maximum number of threads to test
 # d) the relative / absolute tolerances
 # e) the languages to test
+# f) the reaction sorting method to use
 # All test configuration variables  can be specified on the command line via
-# ENV variables if desired
-# e.g. GAS=mymech.cti TEST_PLATFORM=my_platform.yaml nosetests ...
+# ENV variables (prefixed with PYJAC_) if desired
+# e.g. PYJAC_GAS=mymech.cti PYJAC_TEST_PLATFORM=my_platform.yaml nosetests ...
 # or simply feel free to modify the below...
 # NOTE: supplied enviroment variables with override variables set in this test config
 
@@ -32,3 +33,5 @@ config['test_langs'] = 'opencl,c'
 # config['atol'] = 1
 # Set the number of initial conditions for pyJac testing
 # config['test_size'] = 8192
+# Set the type of reaction sorting to utilize
+# config['rxn_sort'] = 'simd'


### PR DESCRIPTION
This enables us to actually use / test the reaction sorting scheme (e.g., via the command line interface or via the `PYJAC_RXN_SORT` environment variable for unit-tests).

In addition, fixes a performance degradation in OpenCL code (compared to paper version) -- the Intel [`pown` function](https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/pow.html) is much slower than our own internal (unrolled) power function, so switch back.