### PR TITLE
Fix-up the non-zero guard, e.g., for division by Pr in the denominator.

### DIFF
--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -2,7 +2,7 @@ nose
 nose-exclude
 nose-testconfig
 nose-timer
-parameterized
+parameterized >= 0.6.3
 optionloop >= 1.0.7
 cantera >= 2.3.0
 scipy

--- a/pyjac/core/create_jacobian.py
+++ b/pyjac/core/create_jacobian.py
@@ -526,7 +526,7 @@ def __dcidE(loopy_opts, namestore, test_size=None,
     # compute guarded exponentials / logs
     expg = ic.GuardedExp(loopy_opts)
     logg = ic.GuardedLog(loopy_opts)
-    guard = ic.Guard(loopy_opts, minv=utils.small)
+    nonzero_guard = ic.NonzeroGuard(loopy_opts)
     if rxn_type != reaction_type.thd:
         # update factors
         factor = 'dci_fall_dE'
@@ -560,7 +560,7 @@ def __dcidE(loopy_opts, namestore, test_size=None,
                 namestore.Fcent, *default_inds)
             kernel_data.extend([Atroe_lp, Btroe_lp, Fcent_lp])
 
-            Pr_g = guard(Pr_str)
+            Pr_g = nonzero_guard(Pr_str)
             log_fcent = logg(Fcent_str)
             dFi_instructions = Template("""
                 <> absqsq = ${Atroe_str} * ${Atroe_str} + \
@@ -594,7 +594,7 @@ def __dcidE(loopy_opts, namestore, test_size=None,
 
             sri_fac = Template(inner).safe_substitute(**locals())
             log_pr = logg(Pr_str)
-            Pr_g = guard(Pr_str)
+            Pr_g = nonzero_guard(Pr_str)
 
             # create insns
             dFi_instructions = Template("""
@@ -648,7 +648,7 @@ def __dcidE(loopy_opts, namestore, test_size=None,
         """).safe_substitute(**locals())
 
     # and update manglers
-    manglers.extend([precompute, expg, logg, guard])
+    manglers.extend([precompute, expg, logg, nonzero_guard])
     rop_net_rev_update = ic.get_update_instruction(
         mapstore, namestore.rop_rev,
         Template(

--- a/pyjac/core/create_jacobian.py
+++ b/pyjac/core/create_jacobian.py
@@ -2282,7 +2282,7 @@ def __dcidT(loopy_opts, namestore, test_size=None,
     # compute guarded exponentials / logs
     expg = ic.GuardedExp(loopy_opts)
     logg = ic.GuardedLog(loopy_opts)
-    guard = ic.Guard(loopy_opts, minv=utils.small)
+    nonzero_guard = ic.NonzeroGuard(loopy_opts)
     if rxn_type != reaction_type.thd:
         # update factors
         factor = 'dci_fall_dT'
@@ -2334,7 +2334,7 @@ def __dcidT(loopy_opts, namestore, test_size=None,
             exp_T3 = expg('-Tval * {troe_T3_str}'.format(troe_T3_str=troe_T3_str))
             exp_T2 = expg('-{troe_T2_str} * Tinv'.format(troe_T2_str=troe_T2_str))
             log_fcent = logg(Fcent_str)
-            Pr_g = guard(Pr_str)
+            Pr_g = nonzero_guard(Pr_str)
 
             dFi_instructions = Template("""
                 <> dFcent = -${troe_a_str} * ${troe_T1_str} * \
@@ -2366,7 +2366,7 @@ def __dcidT(loopy_opts, namestore, test_size=None,
 
             exp_cinv = expg('-Tval * cinv')
             exp_b = expg('-{b_str} * Tinv'.format(b_str=b_str))
-            Pr_g = guard(Pr_str)
+            Pr_g = nonzero_guard(Pr_str)
             log_pr = logg(Pr_str)
             log_val = Template('${a_str} * ${exp_b} + ${exp_cinv}').safe_substitute(
                 **locals())
@@ -2386,7 +2386,7 @@ def __dcidT(loopy_opts, namestore, test_size=None,
         else:
             dFi_instructions = '<> dFi = 0 {id=dFi_final}'
 
-        manglers.extend([expg, logg, guard, precompute])
+        manglers.extend([expg, logg, nonzero_guard, precompute])
 
         fall_instructions = Template("""
         if ${fall_type_str}
@@ -3775,7 +3775,7 @@ def __dci_dnj(loopy_opts, namestore, do_ns=False, fall_type=falloff_form.none,
 
     expg = ic.GuardedExp(loopy_opts)
     logg = ic.GuardedLog(loopy_opts)
-    guard = ic.Guard(loopy_opts, minv=utils.small)
+    nonzero_guard = ic.NonzeroGuard(loopy_opts)
 
     fall_update = ''
     # if we have a falloff term, need to calcule the dFi
@@ -3819,7 +3819,7 @@ def __dci_dnj(loopy_opts, namestore, do_ns=False, fall_type=falloff_form.none,
                 **locals())
             log_val = logg(inner)
             log_pr = logg(Pr_str)
-            pr_g = guard(Pr_str)
+            pr_g = nonzero_guard(Pr_str)
 
             dFi = Template(
                 """
@@ -3840,7 +3840,7 @@ def __dci_dnj(loopy_opts, namestore, do_ns=False, fall_type=falloff_form.none,
             kernel_data.extend([Atroe_lp, Btroe_lp, Fcent_lp])
 
             log_fcent = logg(Fcent_str)
-            pr_g = guard(Pr_str)
+            pr_g = nonzero_guard(Pr_str)
 
             dFi = Template(
                 """
@@ -3888,7 +3888,7 @@ def __dci_dnj(loopy_opts, namestore, do_ns=False, fall_type=falloff_form.none,
         # use a no-op to simplify the dependencies
         fall_update = '... nop {id=fall}'
 
-    manglers.extend([expg, logg, guard])
+    manglers.extend([expg, logg, nonzero_guard])
 
     # create the jacobian update
     jac_update_insn = Template(

--- a/pyjac/core/instruction_creator.py
+++ b/pyjac/core/instruction_creator.py
@@ -413,7 +413,8 @@ class NonzeroGuard(Guard):
             super(NonzeroGuard, self).__init__(loopy_opts)
         self.is_positive = is_positive
         self.limiter = lp_pregen.signaware_limiter_PreambleGen(
-            loopy_opts.lang, limit=limit, vector=loopy_opts.vector_width)
+            loopy_opts.lang, limit=limit, vector=loopy_opts.vector_width,
+            is_simd=loopy_opts.is_simd)
 
     def __operation__(self, value):
         if self.is_positive is None:
@@ -425,14 +426,14 @@ class NonzeroGuard(Guard):
     def _manglers(self):
         manglers = []
         if self.is_positive is None:
-            manglers += [self.limiter.func_mangler()]
-        return manglers + super(Guard, self).manglers
+            manglers += [self.limiter.func_mangler]
+        return manglers + super(NonzeroGuard, self)._manglers()
 
     def _preambles(self):
         preambles = []
         if self.is_positive is None:
             preambles += [self.limiter]
-        return preambles + super(Guard, self).preambles
+        return preambles + super(NonzeroGuard, self)._preambles()
 
 
 class GuardedExp(Guard):

--- a/pyjac/loopy_utils/preambles_and_manglers.py
+++ b/pyjac/loopy_utils/preambles_and_manglers.py
@@ -181,16 +181,17 @@ class fastpowiv_PreambleGen(fastpowi_PreambleGen):
 
 
 class signaware_limiter_PreambleGen(PreambleGen):
-    def __init__(self, lang, limit, vector=None, name='limiter'):
+    def __init__(self, lang, limit, vector=None, name='limiter',
+                 is_simd=False):
         inline = 'static inline ' if lang == 'c' else ''
         double_str = 'double'
-        if vector:
+        if vector and is_simd:
             double_str += str(vector)
         # operators
         code = Template("""
    ${inline}${double_str} ${name}(${double_str} val)
    {
-        return (val < 0) ? (fmin(-${limit}, val) ? fmax(${limit}, val));
+        return (val < 0) ? fmin(-${limit}, val) : fmax(${limit}, val);
    }
    """).substitute(inline=inline, double_str=double_str,
                    name=name, limit=limit)

--- a/pyjac/tests/test_array_splitter.py
+++ b/pyjac/tests/test_array_splitter.py
@@ -449,7 +449,8 @@ def test_get_split_shape(opts):
 
 
 @parameterized(lambda: opts_loop(skip_non_vec=False),
-               doc_func=_split_doc)
+               doc_func=_split_doc,
+               skip_on_empty=True)
 def test_indexer(opts):
     asplit = array_splitter(opts)
 

--- a/pyjac/tests/test_array_splitter.py
+++ b/pyjac/tests/test_array_splitter.py
@@ -190,7 +190,8 @@ def _split_doc(func, num, params):
 
 
 @parameterized(opts_loop,
-               doc_func=_split_doc)
+               doc_func=_split_doc,
+               skip_on_empty=True)
 def test_npy_array_splitter(opts):
     # create array split
     asplit = array_splitter(opts)
@@ -211,7 +212,8 @@ def test_npy_array_splitter(opts):
 
 
 @parameterized(lambda: opts_loop(width=[None]),
-               doc_func=_split_doc)
+               doc_func=_split_doc,
+               skip_on_empty=True)
 def test_lpy_deep_array_splitter(opts):
     from pymbolic.primitives import Subscript, Variable
     # create array split
@@ -264,7 +266,8 @@ def test_lpy_deep_array_splitter(opts):
 
 # currently only have SIMD for wide-vectorizations
 @parameterized(lambda: opts_loop(depth=[None]),
-               doc_func=_split_doc)
+               doc_func=_split_doc,
+               skip_on_empty=True)
 def test_lpy_wide_array_splitter(opts):
     from pymbolic.primitives import Subscript, Variable
     # create array split
@@ -318,7 +321,8 @@ def test_lpy_wide_array_splitter(opts):
 
 
 @parameterized(lambda: opts_loop(depth=[None]),
-               doc_func=_split_doc)
+               doc_func=_split_doc,
+               skip_on_empty=True)
 def test_lpy_iname_presplit(opts):
     """
     Tests that inames access to pre-split inames in non-split loopy arrays are
@@ -401,7 +405,8 @@ def test_atomic_deep_vec_with_small_split():
 
 
 @parameterized(opts_loop,
-               doc_func=_split_doc)
+               doc_func=_split_doc,
+               skip_on_empty=True)
 def test_get_split_shape(opts):
     # create array split
     asplit = array_splitter(opts)
@@ -479,7 +484,8 @@ def test_indexer(opts):
 
 
 @parameterized(lambda: opts_loop(skip_non_vec=False),
-               doc_func=_split_doc)
+               doc_func=_split_doc,
+               skip_on_empty=True)
 def test_get_split_elements(opts):
     # create opts
     asplit = array_splitter(opts)

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
           'nose-exclude',
           'nose-testconfig',
           'nose-timer',
-          'parameterized',
+          'parameterized >= 0.6.3',
           'optionloop >= 1.0.7',
           'cantera >= 2.3.0',
           'scipy',


### PR DESCRIPTION
Here we only need it to be strictly non-zero.

Previously, if the value was negative, using a simple 1-sided guard would send it -> 1e-300.
Dividing by this could blow up the overall value, and cause SigFPE's in OpenFOAM.