### PR TITLE
A proposed solution to fix the non-integer stoichiometric coefficient…

### DIFF
--- a/pyjac/core/array_creator.py
+++ b/pyjac/core/array_creator.py
@@ -2148,14 +2148,14 @@ class NameStore(object):
                                            initializer=off,
                                            order=self.order)
         self.rxn_to_spec_reac_nu = creator('reac_to_spec_nu',
-                                           dtype=kint_type, shape=rate_info[
-                                               'net']['nu'].shape,
+                                           dtype=rate_info['net']['nu'].dtype, 
+                                           shape=rate_info['net']['nu'].shape,
                                            initializer=rate_info['net']['nu'],
                                            order=self.order,
                                            affine=1)
         self.rxn_to_spec_prod_nu = creator('reac_to_spec_nu',
-                                           dtype=kint_type, shape=rate_info[
-                                               'net']['nu'].shape,
+                                           dtype=rate_info['net']['nu'].dtype,
+                                           shape=rate_info['net']['nu'].shape,
                                            initializer=rate_info['net']['nu'],
                                            order=self.order)
 
@@ -2187,7 +2187,9 @@ class NameStore(object):
                                    dtype=kint_type),
             order=self.order)
 
-        self.spec_to_rxn = creator('spec_to_rxn', dtype=kint_type,
+        self.spec_to_rxn = creator('spec_to_rxn', 
+                                   dtype=rate_info['net_per_spec'][
+                                       'reacs'].dtype,
                                    shape=rate_info['net_per_spec'][
                                        'reacs'].shape,
                                    initializer=rate_info[
@@ -2200,7 +2202,9 @@ class NameStore(object):
                                            initializer=off,
                                            order=self.order)
         self.spec_to_rxn_nu = creator('spec_to_rxn_nu',
-                                      dtype=kint_type, shape=rate_info[
+                                      dtype=rate_info[
+                                          'net_per_spec']['nu'].dtype,
+                                      shape=rate_info[
                                           'net_per_spec']['nu'].shape,
                                       initializer=rate_info[
                                           'net_per_spec']['nu'],

--- a/pyjac/core/rate_subs.py
+++ b/pyjac/core/rate_subs.py
@@ -181,7 +181,7 @@ def assign_rates(reacs, specs, rate_spec):
     net_num_spec = np.array(net_num_spec, dtype=arc.kint_type)
     net_spec = np.array(net_spec, dtype=arc.kint_type)
 
-    # sometimes we need the net properties forumlated per species rather than
+    # sometimes we need the net properties formulated per species rather than
     # per reaction as above
     spec_to_reac = []
     spec_nu = []

--- a/pyjac/loopy_utils/preambles_and_manglers.py
+++ b/pyjac/loopy_utils/preambles_and_manglers.py
@@ -57,7 +57,7 @@ class MangleGen(object):
         for i, (d1, d2) in enumerate(zip(self.arg_dtypes, arg_dtypes)):
             if not __compare(d1, d2) and self.raise_on_fail:
                 raise Exception('Argument at index {} for mangler {} does not match'
-                                'expected dtype.  Expected {}, got {}'.format(
+                                ' expected dtype.  Expected {}, got {}'.format(
                                     i, self.name, str(d1), str(d2)))
 
         # get target for creation


### PR DESCRIPTION
… issue (#30) with certain mechanisms. See Issue #30 for further information.

- So in array_creator.py I take the dtype from the rate_info instead of defining it as kint_type.
- In create_jacobian.py I modified the allint variable related parts to be compatible with it's definition.

- The fix has been tested to work with C and OpenCL languages.

However, it is worth noting that this fix has not been tested truly thoroughly. I have compared the reaction rate vectors with cantera in some reference conditions with perfect agreement. However, Jacobian matrices are not tested in detail. I presume testing against finite diff jacobian will be easy for you with your up and running test-bench. 

A second note is that I have noticed a bit weird behavior when using this polimi mechanism (http://creckmodeling.chem.polimi.it/menu-kinetics/menu-kinetics-detailed-mechanisms/menu-kinetics-complete-mechanism) with this fix and with OpenCL language. Sometimes, almost randomly, the pyjac generates species_rate.ocl where the main "species_rates" - kernel lacks the definition for some of the variables it requires (e.g. b, kf, Pr etc.). However, running pyjac a few times again or installing it again typically removes the problem.

I don't know whether the above issue is related to this fix or something deeper within the implementation...

-HK